### PR TITLE
Reorganizes order of array elements to match sequence in METADATA_TYP…

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -1,89 +1,69 @@
 module.exports = [
     {
-        "DeveloperName": "Profiles",
-        "Enabled__c": false,
-        "Additional_Configuration__c": null
-    },
-    {
-        "DeveloperName": "RecordTypes",
-        "Enabled__c": false,
+        "DeveloperName": "CustomObjects",
+        "Enabled__c": true,
         "Additional_Configuration__c": null
     },
     {
         "DeveloperName": "CustomFields",
-        "Enabled__c": false,
-        "Additional_Configuration__c": null
-    },
-    {
-        "DeveloperName": "WorkflowRules",
         "Enabled__c": true,
         "Additional_Configuration__c": null
     },
     {
         "DeveloperName": "FormulaFields",
-        "Enabled__c": false,
-        "Additional_Configuration__c": null
-    },
-    {
-        "DeveloperName": "ListViews",
-        "Enabled__c": false,
-        "Additional_Configuration__c": null
-    },
-    {
-        "DeveloperName": "PicklistValues",
-        "Enabled__c": false,
-        "Additional_Configuration__c": null
-    },
-    {
-        "DeveloperName": "PublicGroups",
-        "Enabled__c": false,
-        "Additional_Configuration__c": null
-    },
-    {
-        "DeveloperName": "ReportTypes",
-        "Enabled__c": false,
+        "Enabled__c": true,
         "Additional_Configuration__c": null
     },
     {
         "DeveloperName": "Roles",
-        "Enabled__c": false,
+        "Enabled__c": true,
         "Additional_Configuration__c": null
     },
     {
-        "DeveloperName": "ValidationRules",
-        "Enabled__c": false,
+        "DeveloperName": "PicklistValues",
+        "Enabled__c": true,
         "Additional_Configuration__c": null
     },
     {
-        "DeveloperName": "CustomObjects",
-        "Enabled__c": false,
+        "DeveloperName": "PublicGroups",
+        "Enabled__c": true,
         "Additional_Configuration__c": null
     },
     {
-        "DeveloperName": "Layouts",
-        "Enabled__c": false,
+        "DeveloperName": "ReportTypes",
+        "Enabled__c": true,
         "Additional_Configuration__c": null
     },
     {
         "DeveloperName": "Reports",
-        "Enabled__c":false,
+        "Enabled__c": true,
         "Additional_Configuration__c": {
             "reportsTimePeriodDays": 120
         }
     },
     {
+        "DeveloperName": "ListViews",
+        "Enabled__c": true,
+        "Additional_Configuration__c": null
+    },
+    {
+        "DeveloperName": "Layouts",
+        "Enabled__c": true,
+        "Additional_Configuration__c": null
+    },
+    {
+        "DeveloperName": "ValidationRules",
+        "Enabled__c": true,
+        "Additional_Configuration__c": null
+    },
+    {
+        "DeveloperName": "EmailTemplates",
+        "Enabled__c": true,
+        "Additional_Configuration__c": null
+    },
+    {
         "DeveloperName": "WorkflowFieldUpdates",
-        "Enabled__c": false,
-        "Additional_Configuration__c": null
-    },
-    {
-        "DeveloperName": "ApexTriggers",
-        "Enabled__c": false,
-        "Additional_Configuration__c": null
-    },
-    {
-        "DeveloperName": "ApexClasses",
-        "Enabled__c": false,
+        "Enabled__c": true,
         "Additional_Configuration__c": null
     },
     {
@@ -92,8 +72,28 @@ module.exports = [
         "Additional_Configuration__c": null
     },
     {
-        "DeveloperName": "EmailTemplates",
-        "Enabled__c": false,
+        "DeveloperName": "WorkflowRules",
+        "Enabled__c": true,
         "Additional_Configuration__c": null
-    }
+    },
+    {
+        "DeveloperName": "ApexTriggers",
+        "Enabled__c": true,
+        "Additional_Configuration__c": null
+    },
+    {
+        "DeveloperName": "ApexClasses",
+        "Enabled__c": true,
+        "Additional_Configuration__c": null
+    },
+    {
+        "DeveloperName": "Profiles",
+        "Enabled__c": true,
+        "Additional_Configuration__c": null
+    },
+    {
+        "DeveloperName": "RecordTypes",
+        "Enabled__c": true,
+        "Additional_Configuration__c": null
+    },
 ]


### PR DESCRIPTION
…ES in MdataIndexer.js. This is meant to make it easier to debug metadata processing by disabling metadata types that are causing trouble.