### PR TITLE
Proposed fixes for issues #2 and #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ For Windows:
 To start mdata use the following command:
 
 ```
-sh mdata_run.sh up
+sh run_mdata.sh up
 ```
 
 If you want to run all the mdata services as a daemon, run below instead:
 
 ```
-sh mdata_run.sh up -d
+sh run_mdata.sh up -d
 ```
 
 __Note__: If this the first time, docker will download, Node, Neo4J and Redis images and it might take some time before the entire thing starts up. Subsequent times will be a lot quicker.

--- a/app/metadata/ReportTypes.js
+++ b/app/metadata/ReportTypes.js
@@ -43,9 +43,13 @@ module.exports = class ReportTypes extends AbstractMetadataType{
         await super.updateMetadataStatus('In Progress', {   type: 'ReportTypes',  totalTypes: reportTypes.length});
         let results = await this.conn.queryAll("select QualifiedApiName,PluralLabel from EntityDefinition");
         let pluralObjNameToAPIName = {};
-        for(var i=0;i<results.records.length;i++){
-            this.logger.debug('['+this.conn.userInfo.organization_id + '] Plural Label:'+results.records[i].PluralLabel+' --> '+results.records[i].QualifiedApiName);
-            pluralObjNameToAPIName[results.records[i].PluralLabel]=results.records[i].QualifiedApiName;
+        if(results){
+            for(var i=0;i<results.length;i++){
+                this.logger.debug('['+this.conn.userInfo.organization_id + '] Plural Label:'+results[i].PluralLabel+' --> '+results[i].QualifiedApiName);
+                pluralObjNameToAPIName[results[i].PluralLabel]=results[i].QualifiedApiName;
+            }
+        } else {
+            this.logger.debug("Attempting to determine custom object developer names from their plural labels failed. Many Report Type and Custom Object nodes will not be related.");
         }
         pluralObjNameToAPIName["Activities"]="Activity";
         for(var i=0;i<reportTypes.length;i++){

--- a/app/web.js
+++ b/app/web.js
@@ -66,7 +66,7 @@ app.use('/plugins/:id/execute',async function (req, res, next) {
     }
 });
 
-app.use(express.static('./app/public'));
+app.use(express.static('./public'));
 
 validOauthHeader = async function(req){
     let authHdr = req.get('Authorization');


### PR DESCRIPTION
Proposed fix for #5:
In createReportTypes() routine
- fixes loop that populates `pluralObjNameToAPIName` map to properly reference results returned from SFConnectUtils.js version of `query()` (as opposed to JSforce version of the same)
- wraps that same loop in a condition to prevent failure if `results` returned from query is null

Proposed fix for #2: Simple edit of endpoint.